### PR TITLE
Page Index Option to Ignore Journal Entries

### DIFF
--- a/zim/config/dicts.py
+++ b/zim/config/dicts.py
@@ -27,9 +27,14 @@ import sys
 import re
 import logging
 import types
-import collections
 import ast
 import json
+
+try:
+	import collections.abc as abc
+except ImportError:
+	# python < version 3.3
+	import collections as abc
 
 from zim.signals import SignalEmitter, ConnectorMixin, SIGNAL_NORMAL
 from zim.utils import OrderedDict
@@ -575,7 +580,7 @@ class ConfigDict(ControlledDict):
 		'''
 		assert not (E and F)
 		update = E or F
-		if isinstance(update, collections.Mapping):
+		if isinstance(update, abc.Mapping):
 			items = list(update.items())
 		else:
 			items = update

--- a/zim/plugins/__init__.py
+++ b/zim/plugins/__init__.py
@@ -36,7 +36,12 @@ import os
 import sys
 import logging
 import inspect
-import collections
+
+try:
+	import collections.abc as abc
+except ImportError:
+	# python < version 3.3
+	import collections as abc
 
 from zim.newfs import LocalFolder, LocalFile
 
@@ -321,7 +326,7 @@ class InsertedObjectTypeMap(SignalEmitter):
 			self.emit('changed')
 
 
-class PluginManagerClass(ConnectorMixin, collections.Mapping):
+class PluginManagerClass(ConnectorMixin, abc.Mapping):
 	'''Manager that maintains a set of active plugins
 
 	This class is the interface towards the rest of the application to

--- a/zim/templates/expression.py
+++ b/zim/templates/expression.py
@@ -35,8 +35,13 @@ These restrictions hsould help to minimize risk of arbitrary code
 execution in expressions.
 '''
 
+try:
+	import collections.abc as abc
+except ImportError:
+	# python < version 3.3
+	import collections as abc
 
-import collections
+
 import inspect
 import logging
 
@@ -292,7 +297,7 @@ class ExpressionFunctionCall(Expression):
 		'''
 		if isinstance(obj, str):
 			return ExpressionStringObject(obj)
-		elif isinstance(obj, (dict, collections.Mapping)):
+		elif isinstance(obj, (dict, abc.Mapping)):
 			return ExpressionDictObject(obj)
 		elif isinstance(obj, list):
 			return ExpressionListObject(obj)

--- a/zim/templates/processor.py
+++ b/zim/templates/processor.py
@@ -10,7 +10,11 @@ expressions in the template.
 '''
 
 
-import collections
+try:
+	import collections.abc as abc
+except ImportError:
+	# python < version 3.3
+	import collections as abc
 
 from zim.utils import MovingWindowIter
 from zim.parser import SimpleTreeElement
@@ -146,9 +150,9 @@ class TemplateProcessor(object):
 		var = element.attrib['var']
 		expr = element.attrib['expr']
 		items = expr(context)
-		if not isinstance(items, collections.Iterable):
+		if not isinstance(items, abc.Iterable):
 			raise TypeError('Can not iterate over: %s' % items)
-		elif not isinstance(items, collections.Sized):
+		elif not isinstance(items, abc.Sized):
 			# cast to list to ensure we have a len()
 			items = list(items)
 

--- a/zim/utils.py
+++ b/zim/utils.py
@@ -186,15 +186,20 @@ class WeakSet(object):
 # Did not switch implementations per version to make sure we test
 # all modules with this implementation
 
-import collections
+try:
+	import collections.abc as abc
+except ImportError:
+	# python < version 3.3
+	import collections as abc
 
-class OrderedDict(collections.MutableMapping):
+
+class OrderedDict(abc.MutableMapping):
 	'''Class that behaves like a dict but keeps items in same order.
 	Updating an items keeps it at the current position, removing and
 	re-inserting an item puts it at the end of the sequence.
 	'''
 
-	# By using collections.MutableMapping we ensure all dict API calls
+	# By using collections.abc.MutableMapping we ensure all dict API calls
 	# are proxied by the methods below. When inheriting from dict
 	# directly e.g. "pop()" does not use "__delitem__()" but is
 	# optimized on it's own


### PR DESCRIPTION
Greetings,

Love zim ... been using for years to manage hectic consulting life.

One workflow item that works well for me is to have journal entries NOT update the page index as switching to a journal page context in the index disrupts my hierarchy.

This PR provides a checkbox in the page index (off by default) but if set, stops Journal pages from updating in the index.   Useful for me, not sure how much for others?
